### PR TITLE
feat: add locale as optional string to FeedClientOptions

### DIFF
--- a/Sources/Models/Feed/FeedClientOptions.swift
+++ b/Sources/Models/Feed/FeedClientOptions.swift
@@ -18,6 +18,7 @@ extension Knock {
         public var has_tenant: Bool? // Optionally scope to notifications with any tenancy or no tenancy
         public var archived: FeedItemArchivedScope? // Optionally scope to a given archived status (defaults to `exclude`)
         public var trigger_data: [String: AnyCodable]? // GenericData
+        public var locale: String? // Optionally scope to a particular locale
         
         public init(from decoder: Decoder) throws {
             let container: KeyedDecodingContainer<FeedClientOptions.CodingKeys> = try decoder.container(keyedBy: FeedClientOptions.CodingKeys.self)
@@ -30,9 +31,10 @@ extension Knock {
             self.has_tenant = try container.decodeIfPresent(Bool.self, forKey: FeedClientOptions.CodingKeys.has_tenant)
             self.archived = try container.decodeIfPresent(Knock.FeedItemArchivedScope.self, forKey: FeedClientOptions.CodingKeys.archived)
             self.trigger_data = try container.decodeIfPresent([String : AnyCodable].self, forKey: FeedClientOptions.CodingKeys.trigger_data)
+            self.locale = try container.decodeIfPresent(String.self, forKey: FeedClientOptions.CodingKeys.locale)
         }
         
-        public init(before: String? = nil, after: String? = nil, page_size: Int? = nil, status: FeedItemScope? = nil, source: String? = nil, tenant: String? = nil, has_tenant: Bool? = nil, archived: FeedItemArchivedScope? = nil, trigger_data: [String : AnyCodable]? = nil) {
+        public init(before: String? = nil, after: String? = nil, page_size: Int? = nil, status: FeedItemScope? = nil, source: String? = nil, tenant: String? = nil, has_tenant: Bool? = nil, archived: FeedItemArchivedScope? = nil, trigger_data: [String : AnyCodable]? = nil, locale: String? = nil) {
             self.before = before
             self.after = after
             self.page_size = page_size
@@ -42,6 +44,7 @@ extension Knock {
             self.has_tenant = has_tenant
             self.archived = archived
             self.trigger_data = trigger_data
+            self.locale = locale
         }
         
         /**
@@ -61,7 +64,8 @@ extension Knock {
                 tenant: self.tenant,
                 has_tenant: self.has_tenant,
                 archived: self.archived,
-                trigger_data: self.trigger_data
+                trigger_data: self.trigger_data,
+                locale: self.locale
             )
             
             // check if the passed options are not nil
@@ -96,6 +100,9 @@ extension Knock {
             }
             if options.trigger_data != nil {
                 mergedOptions.trigger_data = options.trigger_data
+            }
+            if options.locale != nil {
+                mergedOptions.locale = options.locale
             }
             
             return mergedOptions


### PR DESCRIPTION
# feat: add locale as optional string to FeedClientOptions

## Summary
Added a new optional `locale` property to the `FeedClientOptions` struct to allow scoping feed requests to a particular locale. This change is non-breaking as the property is optional with a default value of `nil`.

The implementation adds `locale` in all four required locations:
1. Property declaration (line 21)
2. Custom decoder implementation (line 34)
3. Public initializer parameter with default value (line 37)
4. `mergeOptions` method for proper option merging (lines 68, 104-106)

## Review & Testing Checklist for Human
- [ ] **Verify backend API support**: Confirm that the Knock backend API actually accepts and properly handles a `locale` parameter in feed requests
- [ ] **Test backward compatibility**: Verify that existing code using `FeedClientOptions` without specifying `locale` continues to work correctly
- [ ] **Test locale functionality**: Create a `FeedClientOptions` instance with a `locale` value and verify it's properly passed through to API calls
- [ ] **Review implementation pattern**: Confirm the implementation matches the pattern used for other optional properties (e.g., `tenant`, `source`)

### Test Plan
1. Build the project and ensure it compiles without errors
2. Test creating `FeedClientOptions` without `locale` (should default to `nil`)
3. Test creating `FeedClientOptions` with `locale` specified
4. Test the `mergeOptions` method with locale values
5. If possible, make an actual feed request with a locale value and verify the backend handles it correctly

### Notes
- This change was requested by Chris Bell (chris@knock.app / @cjbell)
- Link to Devin run: https://app.devin.ai/sessions/763f770f905143e3bf45b3a1bdda8012
- The implementation follows the exact same pattern as other optional properties in the struct
- No local build verification was possible due to Swift not being available in the development environment, so CI checks are critical