### PR TITLE
chore: bump version to 1.2.5

### DIFF
--- a/Knock.podspec
+++ b/Knock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Knock"
-  spec.version      = "1.2.4"
+  spec.version      = "1.2.5"
   spec.summary      = "An SDK to build in-app notifications experiences in Swift with Knock."
 
   spec.description  = <<-DESC

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are managing dependencies using the `Package.swift` file, just add this t
 
 ``` swift
 dependencies: [
-    .package(url: "https://github.com/knocklabs/knock-swift.git", .upToNextMajor(from: "1.2.4"))
+    .package(url: "https://github.com/knocklabs/knock-swift.git", .upToNextMajor(from: "1.2.5"))
 ]
 ```
 
@@ -69,7 +69,7 @@ platform :ios, '16.0'
 use_frameworks!
 
 target 'MyApp' do
-  pod 'Knock', '~> 1.2.4'
+  pod 'Knock', '~> 1.2.5'
 end
 ```
 

--- a/Sources/Knock.swift
+++ b/Sources/Knock.swift
@@ -10,7 +10,7 @@ import OSLog
 
 // Knock client SDK.
 public class Knock {
-    internal static let clientVersion = "1.2.4"
+    internal static let clientVersion = "1.2.5"
     
     public static var shared: Knock = Knock()
     


### PR DESCRIPTION
# chore: bump version to 1.2.5

## Summary
Updated the SDK version from 1.2.4 to 1.2.5 across all relevant files:
- `Knock.podspec` - CocoaPods version specification
- `Sources/Knock.swift` - Internal client version constant
- `README.md` - Installation examples for both Swift Package Manager and CocoaPods

## Review & Testing Checklist for Human
- [ ] Verify that 1.2.5 is the correct target version number
- [ ] Confirm whether a CHANGELOG entry or release notes should accompany this version bump
- [ ] Check if any other files (e.g., project files, version tags) need updating

### Notes
- This PR only updates version numbers; no functional code changes were made
- All three locations where version 1.2.4 appeared have been updated to 1.2.5
- Requested by Chris Bell (chris@knock.app) via Slack
- [Link to Devin run](https://app.devin.ai/sessions/02c2463f8e3446c08d87058a66704e7c)