### PR TITLE
chore: add locale query item and bump version

### DIFF
--- a/Knock.podspec
+++ b/Knock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Knock"
-  spec.version      = "1.2.6"
+  spec.version      = "1.2.7"
   spec.summary      = "An SDK to build in-app notifications experiences in Swift with Knock."
 
   spec.description  = <<-DESC

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are managing dependencies using the `Package.swift` file, just add this t
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/knocklabs/knock-swift.git", .upToNextMajor(from: "1.2.6"))
+    .package(url: "https://github.com/knocklabs/knock-swift.git", .upToNextMajor(from: "1.2.7"))
 ]
 ```
 
@@ -66,7 +66,7 @@ platform :ios, '16.0'
 use_frameworks!
 
 target 'MyApp' do
-  pod 'Knock', '~> 1.2.6'
+  pod 'Knock', '~> 1.2.7'
 end
 ```
 

--- a/Sources/Knock.swift
+++ b/Sources/Knock.swift
@@ -10,7 +10,7 @@ import OSLog
 
 // Knock client SDK.
 public class Knock {
-    internal static let clientVersion = "1.2.6"
+    internal static let clientVersion = "1.2.7"
     
     public static var shared: Knock = Knock()
     

--- a/Sources/Modules/FeedModule.swift
+++ b/Sources/Modules/FeedModule.swift
@@ -53,7 +53,8 @@ internal class FeedModule {
             URLQueryItem(name: "has_tenant", value: mergedOptions.has_tenant.stringOrNil()),
             URLQueryItem(name: "status", value: (mergedOptions.status != nil) ? mergedOptions.status?.rawValue : ""),
             URLQueryItem(name: "archived", value: (mergedOptions.archived != nil) ? mergedOptions.archived?.rawValue : ""),
-            URLQueryItem(name: "trigger_data", value: triggerDataJSON)
+            URLQueryItem(name: "trigger_data", value: triggerDataJSON),
+            URLQueryItem(name: "locale", value: mergedOptions.locale)
         ]
         
         do {


### PR DESCRIPTION
## Description

Adds `locale` as a `URLQueryItem` so it will be included on feed requests when it's present in the provided `FeedClientOptions`.