### PR TITLE
fix: Knock.Device parsing instead of casting

### DIFF
--- a/Sources/Modules/ChannelModule.swift
+++ b/Sources/Modules/ChannelModule.swift
@@ -194,18 +194,11 @@ internal class ChannelModule {
             return []
         }
 
-        // AnyCodable decodes arrays as [[String: Any]], not [Knock.Device]
-        guard let deviceDicts = devicesValue as? [[String: Any]] else {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: devicesValue)
+            return try JSONDecoder().decode([Knock.Device].self, from: jsonData)
+        } catch {
             return []
-        }
-
-        return deviceDicts.compactMap { dict -> Knock.Device? in
-            guard let token = dict["token"] as? String else {
-                return nil
-            }
-            let locale = dict["locale"] as? String
-            let timezone = dict["timezone"] as? String
-            return Knock.Device(token: token, locale: locale, timezone: timezone)
         }
     }
 

--- a/Sources/Modules/ChannelModule.swift
+++ b/Sources/Modules/ChannelModule.swift
@@ -79,10 +79,9 @@ internal class ChannelModule {
             let previousTokensFromDevice: [String] = await Knock.shared.environment
                 .getPreviousPushTokens()
 
-            guard
-                let currentDevicesFromServer = channelData.data?["devices"]?.value
-                    as? [Knock.Device]
-            else {
+            let currentDevicesFromServer = parseDevicesFromChannelData(channelData)
+
+            guard !currentDevicesFromServer.isEmpty else {
                 // No valid tokens array found.
                 Knock.shared.log(
                     type: .warning, category: .pushNotification, message: "unregisterTokenForAPNS",
@@ -141,7 +140,7 @@ internal class ChannelModule {
     {
         do {
             let channelData: Knock.ChannelData = try await getUserChannelData(channelId: channelId)
-            let devices = channelData.data?["devices"]?.value as? [Knock.Device] ?? []
+            let devices = parseDevicesFromChannelData(channelData)
 
             let previousTokens: [String] = await Knock.shared.environment.getPreviousPushTokens()
 
@@ -188,6 +187,26 @@ internal class ChannelModule {
             locale: Locale.current.identifier,
             timezone: TimeZone.current.identifier
         )
+    }
+
+    internal func parseDevicesFromChannelData(_ channelData: Knock.ChannelData) -> [Knock.Device] {
+        guard let devicesValue = channelData.data?["devices"]?.value else {
+            return []
+        }
+
+        // AnyCodable decodes arrays as [[String: Any]], not [Knock.Device]
+        guard let deviceDicts = devicesValue as? [[String: Any]] else {
+            return []
+        }
+
+        return deviceDicts.compactMap { dict -> Knock.Device? in
+            guard let token = dict["token"] as? String else {
+                return nil
+            }
+            let locale = dict["locale"] as? String
+            let timezone = dict["timezone"] as? String
+            return Knock.Device(token: token, locale: locale, timezone: timezone)
+        }
     }
 
     internal func filterTokensOutFromDevices(
@@ -302,9 +321,9 @@ public extension Knock {
      This is a convenience method that internally gets the channel data and searches for the token. If it exists, then it's already registered and it returns.
      If the data does not exists or the token is missing from the array, it's added.
      If the new token differs from the last token that was used on the device, the old token will be unregistered.
-    
+
      You can learn more about APNS [here](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns).
-    
+
      - Parameters:
         - channelId: the id of the APNS channel
         - token: the APNS device token as a `String`


### PR DESCRIPTION
cannot cast a dict to an object, need to encode/decode

otherwise, existing tokens are overridden